### PR TITLE
fix popup stickers download from yabe

### DIFF
--- a/download.py
+++ b/download.py
@@ -15,10 +15,14 @@ from spider import DownloadThread
 from utils import SET_URL_TEMPLATES, STICKER_URL_TEMPLATES, StickerType, StickerSetSource
 
 
-def prepare_video_sticker_icon(pack_id, temp_dir, output_path, proxies=None):
+def prepare_video_sticker_icon(pack_id, temp_dir, output_path, sticker_type, proxies=None):
     from spider import download_file
     from processing import process_video_or_regular_sticker_icon
-    url = STICKER_URL_TEMPLATES[StickerType.MAIN_ANIMATION].format(pack_id=pack_id)
+    if sticker_type in [StickerType.POPUP_AND_SOUND_STICKER,
+                        StickerType.POPUP_STICKER]:
+        url = STICKER_URL_TEMPLATES[StickerType.MAIN_POPUP].format(pack_id=pack_id)
+    else:
+        url = STICKER_URL_TEMPLATES[StickerType.MAIN_ANIMATION].format(pack_id=pack_id)
     download_path = os.path.join(temp_dir, 'mainimg.png')
 
     download_file(url, download_path, proxies)
@@ -184,6 +188,7 @@ def main():
         if option == ProcessOption.TO_WEBM:
             print('Downloading icon for webm stickers...')
             prepare_video_sticker_icon(args.id, sticker_temp_store_path, os.path.join(sticker_root_path, 'icon.webm'),
+                                       sticker_type,
                                        proxies)
         print('Process done!')
     # remove temp dir

--- a/parse.py
+++ b/parse.py
@@ -21,14 +21,14 @@ def parse_page_yabe(content: bytes):
     talk_icon = soup.select_one('div.stickerData div.talkIcon')
     move_icon = soup.select_one('div.stickerData div.moveIcon')
     popup_icon = soup.select_one('div.stickerData div.PopUpIcon')
-    if talk_icon and move_icon:
-        sticker_type = StickerType.ANIMATED_AND_SOUND_STICKER
-    elif talk_icon and popup_icon:
+    if talk_icon and popup_icon:
         sticker_type = StickerType.POPUP_AND_SOUND_STICKER
-    elif talk_icon:
-        sticker_type = StickerType.STATIC_WITH_SOUND_STICKER
     elif popup_icon:
         sticker_type = StickerType.POPUP_STICKER
+    elif talk_icon and move_icon:
+        sticker_type = StickerType.ANIMATED_AND_SOUND_STICKER
+    elif talk_icon:
+        sticker_type = StickerType.STATIC_WITH_SOUND_STICKER
     elif move_icon:
         sticker_type = StickerType.ANIMATED_STICKER
     title = soup.select_one('div.stickerData div.title')

--- a/utils.py
+++ b/utils.py
@@ -10,6 +10,7 @@ class StickerType(Enum):
     POPUP_AND_SOUND_STICKER = 'popup&sound'
     SOUND = 'sound'
     MAIN_ANIMATION = 'main_animation'
+    MAIN_POPUP = 'main_popup'
 
 
 class StickerSetSource(Enum):
@@ -29,8 +30,9 @@ STICKER_URL_TEMPLATES = {
     StickerType.ANIMATED_STICKER: 'https://stickershop.line-scdn.net/stickershop/v1/sticker/{id}/IOS/sticker_animation@2x.png',
     StickerType.MAIN_ANIMATION: 'https://stickershop.line-scdn.net/stickershop/v1/product/{pack_id}/IOS/main_animation.png',
     StickerType.ANIMATED_AND_SOUND_STICKER: 'https://stickershop.line-scdn.net/stickershop/v1/sticker/{id}/IOS/sticker_animation@2x.png',
-    StickerType.POPUP_STICKER: 'https://stickershop.line-scdn.net/stickershop/v1/sticker/{id}/IOS/sticker_popup@2x.png',
-    StickerType.POPUP_AND_SOUND_STICKER: 'https://stickershop.line-scdn.net/stickershop/v1/sticker/{id}/IOS/sticker_popup@2x.png'
+    StickerType.POPUP_STICKER: 'https://stickershop.line-scdn.net/stickershop/v1/sticker/{id}/IOS/sticker_popup.png',
+    StickerType.POPUP_AND_SOUND_STICKER: 'https://stickershop.line-scdn.net/stickershop/v1/sticker/{id}/IOS/sticker_popup.png',
+    StickerType.MAIN_POPUP: 'https://stickershop.line-scdn.net/stickershop/v1/product/{pack_id}/IOS/main_popup.png',
 }
 FAKE_HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36'


### PR DESCRIPTION
Since `talk_icon`, `popup_icon` and `move_icon` can appear at the same time(e.g. [7654-ㄇㄚˊ幾兔-全螢幕貼圖](http://yabeline.tw/Stickers_Data.php?Number=7654)), and I guess it's ok to assume that `popup_icon` and `move_icon` always appear at the same time(based on the [search results](http://yabeline.tw/Stickers_Search.php?Search=%E5%85%A8%E8%9E%A2%E5%B9%95%E8%B2%BC%E5%9C%96&page=1)), so originally pack 7654 is recognized as `ANIMATED_AND_SOUND_STICKER`, but it's actually `POPUP_AND_SOUND_STICKER` instead. 

And it seems that the sticker icon naming on yabe for `POPUP_STICKER|POPUP_AND_SOUND_STICKER` is different from others, it's `main_popup.png` now, not `main_animation.png`. (e.g. [7654-ㄇㄚˊ幾兔-全螢幕貼圖](http://yabeline.tw/Stickers_Data.php?Number=7654))

Also, based on my testing, the URL templates for `POPUP_STICKER|POPUP_AND_SOUND_STICKER` become `sticker_popup.png` instead of `sticker_popup@2x.png`. (e.g. [7654-ㄇㄚˊ幾兔-全螢幕貼圖](http://yabeline.tw/Stickers_Data.php?Number=7654))

But I haven't checked whether these changes will affect the compatibility with `--source line`.