### PR TITLE
Fix issues of preserving alpha channel when scaling some stickers

### DIFF
--- a/processing.py
+++ b/processing.py
@@ -71,8 +71,8 @@ class ImageProcessorThread(Thread):
                 self.queue.task_done()
 
     def scale_image(self, in_file, out_file):
-        ffmpeg.input(in_file).filter('scale', w='if(gt(iw,ih),512,-1)', h='if(gt(iw,ih),-1,512)').output(out_file).run(
-            quiet=True)
+        ffmpeg.input(in_file).filter('scale', w='if(gt(iw,ih),512,-1)', h='if(gt(iw,ih),-1,512)').output(
+            out_file, pix_fmt='rgba').run(quiet=True)
 
     def remove_alpha_geq(self, in_stream):
         """


### PR DESCRIPTION
Without `pix_fmt='rgba'`, alpha channels might be lost when scaling some stickers with `pal8` input, e.g. https://yabeline.tw/Stickers_Data.php?Number=19306143. 
